### PR TITLE
bump version of kommander chart

### DIFF
--- a/addons/kommander/1.x/kommander-9.yaml
+++ b/addons/kommander/1.x/kommander-9.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-8"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-9"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.6
+    version: 0.4.8
     values: |
       ---
       ingress:


### PR DESCRIPTION
- 0.4.8 it is, to include latest KCL release