### PR TITLE
[D2IQ-61246] using reloader to upgrade properly

### DIFF
--- a/addons/kommander/1.x/kommander-10.yaml
+++ b/addons/kommander/1.x/kommander-10.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-9"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-10"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -55,6 +55,13 @@ spec:
             kind: ClusterIssuer
         konvoy:
           allowUnofficialReleases: true
+        kubefed:
+          controllermanager:
+            annotations:
+              secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+            webhook:
+              annotations:
+                secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
 
       kommander-karma:
         karma:

--- a/addons/kommander/1.x/kommander-10.yaml
+++ b/addons/kommander/1.x/kommander-10.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: kommander
+  labels:
+    kubeaddons.mesosphere.io/name: kommander
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-9"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
+    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
+    appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
+    appversion.kubeaddons.mesosphere.io/karma: 1.4.0
+    appversion.kubeaddons.mesosphere.io/kommander-grafana: 6.6.0
+    endpoint.kubeaddons.mesosphere.io/thanos: /ops/portal/kommander/monitoring/query
+    endpoint.kubeaddons.mesosphere.io/karma: /ops/portal/kommander/monitoring/karma
+    endpoint.kubeaddons.mesosphere.io/kommander-grafana: "/ops/portal/kommander/monitoring/grafana"
+    docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
+    docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
+    docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
+spec:
+  namespace: kommander
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: kommander
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.4.8
+    values: |
+      ---
+      ingress:
+        extraAnnotations:
+          traefik.ingress.kubernetes.io/priority: "2"
+
+      kommander-cluster-lifecycle:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+        konvoy:
+          allowUnofficialReleases: true
+
+      kommander-karma:
+        karma:
+          deployment:
+            annotations:
+              configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+
+      kubeaddons-catalog:
+        image:
+          repository: mesosphere/kubeaddons-catalog
+          tag: "v0.5.3"
+          pullPolicy: IfNotPresent


### PR DESCRIPTION
This was tested on a konvoy cluster and upgrading from version 1.3.0 to the latest version of kommander using the following cluster.yaml entries:

```
  - configRepository: https://github.com/mesosphere/kubeaddons-kommander
    configVersion: ae/reloader
    addonsList:
    - name: kommander
      enabled: true
  - configRepository: https://github.com/mesosphere/kubernetes-base-addons
    configVersion: master
    addonsList:
   ...
```

The reloader annotation allows for new cert to be consumed properly and allows clusters to continue to join without a problem. Note that this only happens with this upgrade case. The upgrade from latest to latest case works as expected as no new certificates are created. 