### PR TITLE
Bump Kommander chart

### DIFF
--- a/addons/kommander/1.x/kommander-11.yaml
+++ b/addons/kommander/1.x/kommander-11.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: kommander
+  labels:
+    kubeaddons.mesosphere.io/name: kommander
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-10"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
+    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
+    appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
+    appversion.kubeaddons.mesosphere.io/karma: 1.4.0
+    appversion.kubeaddons.mesosphere.io/kommander-grafana: 6.6.0
+    endpoint.kubeaddons.mesosphere.io/thanos: /ops/portal/kommander/monitoring/query
+    endpoint.kubeaddons.mesosphere.io/karma: /ops/portal/kommander/monitoring/karma
+    endpoint.kubeaddons.mesosphere.io/kommander-grafana: "/ops/portal/kommander/monitoring/grafana"
+    docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
+    docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
+    docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
+spec:
+  namespace: kommander
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: kommander
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.4.8
+    values: |
+      ---
+      ingress:
+        extraAnnotations:
+          traefik.ingress.kubernetes.io/priority: "2"
+
+      kommander-cluster-lifecycle:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+        konvoy:
+          allowUnofficialReleases: true
+        kubefed:
+          controllermanager:
+            annotations:
+              secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+            webhook:
+              annotations:
+                secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+
+      kommander-karma:
+        karma:
+          deployment:
+            annotations:
+              configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+
+      kubeaddons-catalog:
+        image:
+          repository: mesosphere/kubeaddons-catalog
+          tag: "v0.5.3"
+          pullPolicy: IfNotPresent

--- a/addons/kommander/1.x/kommander-11.yaml
+++ b/addons/kommander/1.x/kommander-11.yaml
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.8
+    version: 0.4.11
     values: |
       ---
       ingress:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-64099
Bumps the `kommander` chart to pull in the latest changes which added the secret reloader annotations for karma and thanos proxies.

The following needs to be done (with #438 merge):
1. Bump the version of `mtls-proxy` used in `kommander-thanos` and `kommander-karma` and add the `secret.reloader.stakater.com/reload` annotations ✅ **DONE IN https://github.com/mesosphere/charts/pull/443**
1. Bump the deps of `kommander-thanos` and `kommander-karma` in `kommander` chart to pull in the latest changes from the above ✅ **DONE IN https://github.com/mesosphere/charts/pull/446**
1. Bump kommander version in `kubeaddons-kommander` ✅ **DONE IN THIS PR**

## Testing
I tested this manually by hosting `mtls-proxy`, `kommander-thanos`, `kommander-karma`, and `kommander charts` on my personal GH. I `konvoy up` on addons version `master`, then upgraded the kommander chart by deploying addons with my `kubeaddons-kommander` branch `gracedo/bug_certs_D2IQ-64099` (this branch has obviously now been updated to mesosphere's hosted kommander chart).
```
  - configRepository: https://github.com/mesosphere/kubeaddons-kommander
    #configVersion: master
    configVersion: gracedo/bug_certs_D2IQ-64099
    addonsList:
    - name: kommander
      enabled: true
```

Upon upgrading, I verified that updated secrets were federated out to the managed clusters (as they were before) then checked that the proxies now had the reloader annotation:
![image](https://user-images.githubusercontent.com/5897740/74793791-41b1a080-5276-11ea-83dc-606c82f3e7b1.png)
![image](https://user-images.githubusercontent.com/5897740/74793850-745b9900-5276-11ea-9aa4-557009e18cb5.png)

I checked Thanos and Karma UIs in the kommander cluster and saw that they were still able to connect to the proxies even after upgrading
![image](https://user-images.githubusercontent.com/5897740/74793881-92c19480-5276-11ea-9c3d-e99358b6b834.png)
![image](https://user-images.githubusercontent.com/5897740/74793889-97864880-5276-11ea-8859-ace360c1a56f.png)
