### PR TITLE
[bug] patch api image overrides

### DIFF
--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-13"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-14"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -72,5 +72,5 @@ spec:
       kubeaddons-catalog:
         image:
           repository: mesosphere/kubeaddons-catalog
-          tag: "v0.5.3"
+          tag: "v0.8.2"
           pullPolicy: IfNotPresent


### PR DESCRIPTION
As per [D2IQ-64567](https://jira.d2iq.com/browse/D2IQ-64567) this image override needs to be updated to the latest release provided by the chart.