### PR TITLE
Remove kubernetes 1.15 from UI selection

### DIFF
--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-16"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-17"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -74,3 +74,6 @@ spec:
           repository: mesosphere/kubeaddons-catalog
           tag: "v0.8.2"
           pullPolicy: IfNotPresent
+
+      kommander-ui:
+        kubernetesVersionsSelection: '["1.16.4", "1.16.3"]'


### PR DESCRIPTION
This should only stay here as an overwrite until we bump the chart version 