### PR TITLE
Bump Kommander to 0.4.16

### DIFF
--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-14"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-15"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.15
+    version: 0.4.16
     values: |
       ---
       ingress:


### PR DESCRIPTION
Bumps Kommander to pull in the latest changes to the chart (fixes a graph on the clusters summary grafana dashboard) https://github.com/mesosphere/charts/pull/460