### PR TITLE
Reload Karma and Thanos Query on changes to TLS secrets

### DIFF
--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-17"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-18"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9

--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -68,6 +68,13 @@ spec:
           deployment:
             annotations:
               configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+              secret.reloader.stakater.com/reload: kommander-karma-client-tls
+
+      kommander-thanos:
+        thanos:
+          query:
+            deploymentAnnotations:
+              secret.reloader.stakater.com/reload: kommander-thanos-client-tls
 
       kubeaddons-catalog:
         image:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-64819

This causes Reloader to restart Karma and Thanos deployments when their TLS secrets are modified. Without this PR, Karma and Thanos may use stale certificates, and fail to connect to managed clusters.

## Testing

I tested this PR by deploying a cluster with the kommander configversion set to this branch:

```
  - configRepository: https://github.com/branden/kubeaddons-kommander
    configVersion: central-monitoring-reload
    addonsList:
    - name: kommander
      enabled: true
```

I then edited the secrets `kommander-karma-client-tls` and `kommander-thanos-client-tls` in the `kommander` namespace, and observed that the deployments `kommander-kubeaddons-thanos-query` and `kommander-kubeaddons-karma` were restarted with new pods.