### PR TITLE
[Release branch] 🚄 Kommander GA RC1 Bump

### DIFF
--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-16"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-17"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9

--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -72,5 +72,5 @@ spec:
       kubeaddons-catalog:
         image:
           repository: mesosphere/kubeaddons-catalog
-          tag: "v0.8.2"
+          tag: "v0.8.3"
           pullPolicy: IfNotPresent

--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.18
+    version: 0.4.20
     values: |
       ---
       ingress:

--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -53,8 +53,6 @@ spec:
           issuer:
             name: kubernetes-ca
             kind: ClusterIssuer
-        konvoy:
-          allowUnofficialReleases: true
         kubefed:
           controllermanager:
             annotations:

--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -74,3 +74,6 @@ spec:
           repository: mesosphere/kubeaddons-catalog
           tag: "v0.8.3"
           pullPolicy: IfNotPresent
+
+      kommander-ui:
+        kubernetesVersionsSelection: '["1.16.4", "1.16.3"]'


### PR DESCRIPTION
⚠️ depends on https://github.com/mesosphere/charts/pull/471 being merged

this bumps latest chart changes on stable-1.16-1.0.0 release branch.
it also includes https://github.com/mesosphere/kubeaddons-kommander/pull/18 and https://github.com/mesosphere/kubeaddons-kommander/pull/23 which originally targeted `master` branch (cc @gracedo & @DanielMSchmidt)