### PR TITLE
[chore] update the kommander catalog api server

### DIFF
--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -79,7 +79,7 @@ spec:
       kubeaddons-catalog:
         image:
           repository: mesosphere/kubeaddons-catalog
-          tag: "v0.8.2"
+          tag: "v0.8.3"
           pullPolicy: IfNotPresent
 
       kommander-ui:


### PR DESCRIPTION
`v0.8.3` includes changes which identify our enterprise repository as a "core" type repository.