### PR TITLE
update chart version of kommander to 0.4.22

### DIFF
--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-18"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-19"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.18
+    version: 0.4.21
     values: |
       ---
       ingress:

--- a/addons/kommander/1.x/kommander.yaml
+++ b/addons/kommander/1.x/kommander.yaml
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.21
+    version: 0.4.22
     values: |
       ---
       ingress:


### PR DESCRIPTION
This PR is related to the release of kcl; released and bumped to v0.4.10. This includes:
- enable self-attaching Kommander
- chore: bump konvoy to v1.4.0 
- Add cluster count tracking to licenses (#352)
- chore: Use mesosphere build of kubefed
- fix: Check namespace is found before unjoining (#448) 
- chore: bump kubeaddons fed version
- chore: add opsportal roles
- chore: add default dashboard roles to default workspace
- kommander: bump kommander-ui ingress priority (https://github.com/mesosphere/charts/pull/474)