### PR TITLE
fix: bump kommander to 0.4.26

### DIFF
--- a/addons/kommander/1.0.x/kommander.yaml
+++ b/addons/kommander/1.0.x/kommander.yaml
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.25
+    version: 0.4.26
     values: |
       ---
       ingress:


### PR DESCRIPTION
This includes KCL v0.4.11

```
$ git log --pretty=oneline v0.4.10...v0.4.11
0f6948512fe8ea32ab7f84598c6caa08fc823880 feat: use different weight for federated /ops/portal ingress (#451)
e9544300716d33bb3525a153b2ff2e6b0dd759f2 test: add arn roles in a separate test
e3260b21e4fe5cc3f6899f75a8336d8ded8e045d test: fix wrong error message
b093a606729e27a028e466f55e4e7b8be5f68a25 test: configure arn role when the env var is true
369e20af4a3f4755a59975041af2fbef3fe257e0 chore: add new env var to use arn roles
```