### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mesosphere/sig-ksphere-catalog @juliangieseke
+* @mesosphere/sig-ksphere-catalog @mesosphere/sig-ksphere-ui 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mesosphere/sig-ksphere-catalog
+* @mesosphere/sig-ksphere-catalog @juliangieseke

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mesosphere/sig-ksphere-catalog @mesosphere/sig-ksphere-ui 
+* @mesosphere/sig-ksphere-catalog @mesosphere/sig-ksphere-ui @mesosphere/sig-ksphere-multi-cluster @mesosphere/sig-ksphere-observability 


### PR DESCRIPTION
This PR adds ksphere ui as a codeowner over this repository as per the [catalog codeowners guide](https://github.com/mesosphere/ksphere-platform/blob/master/docs/sig-ksphere-catalog/codeowners-guide.md).