### PR TITLE
fix: bump kommander to 0.5.1 (#35)

### DIFF
--- a/addons/kommander/1.0.x/kommander.yaml
+++ b/addons/kommander/1.0.x/kommander.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-20"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.0.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
     appversion.kubeaddons.mesosphere.io/karma: 1.4.0
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.4.26
+    version: 0.5.1
     values: |
       ---
       ingress:


### PR DESCRIPTION
This includes KCL v0.5.0:

```
$ git log --pretty=oneline v0.4.11...v0.5.0
D2IQ-65193: Create separate clientapis module (#460)
fix: don't use a finalizer from LicenseClusterCount (#458)
fix: Fix up kommander kubefed requeue intervals
test: deployment ready gomega matcher
chore: move test around
test(e2e): add non-konvoy federated addon assertion
feat: Configurable Konvoy (de)provisioning retries
refactor: Add scheme to controllers helper
fix: fixed instructions in README
chore: bump kubefed version to v0.2.0-alpha.1
chore: Upgrade to kubeaddons 0.9.7
chore: Upgrade golangci-lint to 1.23.7
chore: Fix up broken test flags on darwin
chore: Upgrade to golang 1.14.0
```