### PR TITLE
chore: bump kommander chart reference 0.5.2 -> 0.5.7

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-3"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.5.2
+    version: 0.5.7
     values: |
       ---
       ingress:


### PR DESCRIPTION
https://github.com/mesosphere/charts/commits/master/stable/kommander

```
History for charts/stable/kommander
Commits on Mar 25, 2020
[kommander] Revert "chore: move values from addon to chart" (#515) …

@juliangieseke
@alejandroEsc
juliangieseke and alejandroEsc committed 3 minutes ago
  
[kommander] bump UI & KCL (#519) …

@juliangieseke
juliangieseke committed 31 minutes ago
  
Commits on Mar 24, 2020
fix: federate karma-proxy only to Konvoy clusters (#516)

@timaa2k
timaa2k committed 16 hours ago
  
Commits on Mar 23, 2020
chore: move values from addon to chart

@juliangieseke
juliangieseke committed 2 days ago
 
Commits on Mar 19, 2020
refactor(kommander): Use thanos & karma source code as subcharts (#453)

@samvantran
samvantran committed 6 days ago
  
Commits on Mar 18, 2020
chore: bump kommander ui chart

@juliangieseke
juliangieseke committed 8 days ago
 
```