### PR TITLE
podAnnotations to the kommander-ui 

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-4"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9

--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -84,3 +84,5 @@ spec:
 
       kommander-ui:
         kubernetesVersionsSelection: '["1.16.4", "1.16.3"]'
+        podAnnotations: {}
+        #  iam.amazonaws.com/role: xyz


### PR DESCRIPTION
adding the ability to pass podAnnotations to the kommander-ui deployment so that we can take advantage of being able to utilize the use of kiam or kube2iam to read from AWS IAM roles from the pod. Per Jira D2IQ-64907