### PR TITLE
ingress values for kubeaddons-catalog

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -81,6 +81,10 @@ spec:
           repository: mesosphere/kubeaddons-catalog
           tag: "v0.8.3"
           pullPolicy: IfNotPresent
+        ingress:
+          enable: false
+          hostName: catalog.kubeaddons.localhost
+          annotations: {}
 
       kommander-ui:
         kubernetesVersionsSelection: '["1.16.4", "1.16.3"]'


### PR DESCRIPTION
Per [D2IQ-64149,](urhttps://jira.d2iq.com/browse/D2IQ-64149l) we are experiencing the following error when requesting cert from Lets Encrypt: 

`{"level":"info","msg":"legolog: [INFO] [catalog.kubeaddons.localhost] acme: Obtaining bundled SAN certificate","time":"2020-02-11T20:42:58Z"}
{"level":"error","msg":"Unable to obtain ACME certificate for domains \"catalog.kubeaddons.localhost\" detected thanks to rule \"Host:catalog.kubeaddons.localhost\" : unable to generate a certificate for the domains [catalog.kubeaddons.localhost]: acme: error: 400 :: POST :: https://acme-staging-v02.api.letsencrypt.org/acme/new-order :: urn:ietf:params:acme:error:rejectedIdentifier :: Error creating new order :: Cannot issue for \"catalog.kubeaddons.localhost\": Domain name does not end with a valid public suffix (TLD), url: ","time":"2020-02-11T20:42:58Z"}`

The values for the Ingress are being preset and we would like the option to modify whether or not the Ingress resource is created and also the host that is used for it. 

Per ticket, Sam and Shane have decided that we should disable the Ingress as a default. We should be okay either was as long as we make it adjustable to the user. 