### PR TITLE
chore: bump kommander chart version

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-11"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-12"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-beta.2"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.6.15
+    version: 0.6.16
     values: |
       ---
       ingress:
@@ -88,5 +88,6 @@ spec:
 
       kommander-ui:
         kubernetesVersionsSelection: '["1.16.4", "1.16.3"]'
+        env: {}
         podAnnotations: {}
         #  iam.amazonaws.com/role: xyz

--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -88,6 +88,5 @@ spec:
 
       kommander-ui:
         kubernetesVersionsSelection: '["1.16.4", "1.16.3"]'
-        env: {}
         podAnnotations: {}
         #  iam.amazonaws.com/role: xyz


### PR DESCRIPTION
- new version 0.6.16

[D2IQ-67881] #comment kubeaddons-kommander updated

[D2IQ-67881]: https://jira.d2iq.com/browse/D2IQ-67881