### PR TITLE
chore: bump KCL to v0.6.20

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-14"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-15"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-beta.3"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.6.19
+    version: 0.6.20
     values: |
       ---
       ingress:


### PR DESCRIPTION
Depends on https://github.com/mesosphere/charts/pull/587/files