### PR TITLE
[DO-NOT-MERGE] chore: skip yakcl-provisioning in kommander

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-20"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-21"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -49,10 +49,12 @@ spec:
           traefik.ingress.kubernetes.io/priority: "2"
 
       yakcl-provisioning:
+        enabled: false
         certificates:
           issuer:
             name: kubernetes-ca
             kind: ClusterIssuer
+     
       yakcl-licensing:
         certificates:
           issuer:

--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-19"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-20"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,14 +41,24 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.7.5
+    version: 0.8.1
     values: |
       ---
       ingress:
         extraAnnotations:
           traefik.ingress.kubernetes.io/priority: "2"
 
-      kommander-cluster-lifecycle:
+      yakcl-provisioning:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+      yakcl-licensing:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+      yakcl-federation:
         certificates:
           issuer:
             name: kubernetes-ca


### PR DESCRIPTION
Deploy kommander without yakcl-provisioning for testing with Konvoy.