### PR TITLE
chore: Bump kommmander chart to 0.8.2, add kubecost label

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-20"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-21"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.8.1
+    version: 0.8.2
     values: |
       ---
       ingress:
@@ -99,3 +99,9 @@ spec:
       kommander-ui:
         podAnnotations: {}
         #  iam.amazonaws.com/role: xyz
+
+      kubecost:
+        cost-analyzer:
+          kubecostDeployment:
+            labels:
+              vendor.kubecost.io/partner: d2iq

--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-21"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-22"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.8.2
+    version: 0.8.3
     values: |
       ---
       ingress:

--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-22"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-23"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9


### PR DESCRIPTION
Bumps kommander chart to 0.8.2 which allows us to add kubecost deployment label