### PR TITLE
chore: bump yakcl chart and disable provisioning module

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-24"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-25"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.8.5
+    version: 0.8.6
     values: |
       ---
       ingress:
@@ -49,10 +49,7 @@ spec:
           traefik.ingress.kubernetes.io/priority: "2"
 
       yakcl-provisioning:
-        certManagerCertificates:
-          issuer:
-            name: kubernetes-ca
-            kind: ClusterIssuer
+        enabled: false
       yakcl-licensing:
         certificates:
           issuer:


### PR DESCRIPTION
We need to release a version to deploy it with Konvoy 1.5.0-rc.1 where yakcl-provisioning is deployed by Konvoy oftb. Therefore we cannot deployed via kommander.