### PR TITLE
chore: bump kommander chart

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-34"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-35"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.3"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.8.15
+    version: 0.8.16
     values: |
       ---
       ingress:


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-68100

This bumps the Kommander chart version to pull in https://github.com/mesosphere/charts/pull/626.

I tested this PR  by deploying a Konvoy 1.15 cluster with the Kommander addon's configversion set to this branch. Kommander deploys successfully, `/ops/portal/kommander/kubecost` redirects to `/ops/portal/kommander/kubecost/`, and the Kubecost UI shows the cluster and its projected cost.