### PR TITLE
chore: Bump kommander chart

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-37"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-38"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.4"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.8.17
+    version: 0.8.19
     values: |
       ---
       ingress:

--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-38"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-39"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.4"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.8.19
+    version: 0.8.20
     values: |
       ---
       ingress:


### PR DESCRIPTION
Bumps kommander to latest version to pull in https://github.com/mesosphere/charts/pull/640. Will rebase once #96 is merged