### PR TITLE
fix: Add reloader annotation to thanos query deployment

### DIFF
--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-38"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-39"
     appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.4"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21

--- a/addons/kommander/1.1.x/kommander.yaml
+++ b/addons/kommander/1.1.x/kommander.yaml
@@ -102,3 +102,7 @@ spec:
           kubecostDeployment:
             labels:
               vendor.kubecost.io/partner: d2iq
+          thanos:
+            query:
+              deploymentAnnotations:
+                secret.reloader.stakater.com/reload: kommander-kubecost-thanos-client-tls


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-69520
Add reloader annotation to thanos query deployment so it redeploys every time the secret its watching is updated. 