### PR TITLE
chore: bump kommander chart to 0.8.24

### DIFF
--- a/addons/kommander/1.1.0/kommander-41.yaml
+++ b/addons/kommander/1.1.0/kommander-41.yaml
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.8.22
+    version: 0.8.24
     values: |
       ---
       ingress:

--- a/addons/kommander/1.1.0/kommander-41.yaml
+++ b/addons/kommander/1.1.0/kommander-41.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: kommander
+  labels:
+    kubeaddons.mesosphere.io/name: kommander
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-40"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.1.0-rc.4"
+    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
+    appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
+    appversion.kubeaddons.mesosphere.io/karma: 1.4.1
+    appversion.kubeaddons.mesosphere.io/kommander-grafana: 6.6.0
+    endpoint.kubeaddons.mesosphere.io/thanos: /ops/portal/kommander/monitoring/query
+    endpoint.kubeaddons.mesosphere.io/karma: /ops/portal/kommander/monitoring/karma
+    endpoint.kubeaddons.mesosphere.io/kommander-grafana: "/ops/portal/kommander/monitoring/grafana"
+    docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
+    docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
+    docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
+spec:
+  namespace: kommander
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: kommander
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.8.22
+    values: |
+      ---
+      ingress:
+        extraAnnotations:
+          traefik.ingress.kubernetes.io/priority: "2"
+
+      kommander-licensing:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+      kommander-federation:
+        utilityApiserver:
+          minimumKubernetesVersion: 1.16.0
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+        konvoy:
+          allowUnofficialReleases: true
+        kubefed:
+          controllermanager:
+            annotations:
+              secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+            webhook:
+              annotations:
+                secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+
+      kommander-karma:
+        karma:
+          deployment:
+            annotations:
+              configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+              secret.reloader.stakater.com/reload: kommander-karma-client-tls
+
+      kommander-thanos:
+        thanos:
+          query:
+            deploymentAnnotations:
+              secret.reloader.stakater.com/reload: kommander-thanos-client-tls
+
+      kubeaddons-catalog:
+        image:
+          repository: mesosphere/kubeaddons-catalog
+          tag: "v0.8.3"
+          pullPolicy: IfNotPresent
+        ingress:
+          enable: false
+          hostName: catalog.kubeaddons.localhost
+          annotations: {}
+
+      kommander-ui:
+        podAnnotations: {}
+        #  iam.amazonaws.com/role: xyz
+
+      kubecost:
+        cost-analyzer:
+          kubecostDeployment:
+            labels:
+              vendor.kubecost.io/partner: d2iq
+          thanos:
+            query:
+              deploymentAnnotations:
+                secret.reloader.stakater.com/reload: kommander-kubecost-thanos-client-tls


### PR DESCRIPTION

**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
Update kommander chart to include kubecost fixes
- https://github.com/mesosphere/charts/pull/652
- https://github.com/mesosphere/charts/pull/646

**Which issue(s) this PR fixes**:
no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [x] The commit message explains the changes and why are needed.
- [x] The code builds and passes lint/style checks locally.
- [x] The relevant subset of integration tests pass locally.
- [x] The core changes are covered by tests.
- [x] The documentation is updated where needed.
