### PR TITLE
bump kommander ui 1.2 beta

### DIFF
--- a/addons/kommander/1.2.0/kommander-5.yaml
+++ b/addons/kommander/1.2.0/kommander-5.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: kommander
+  labels:
+    kubeaddons.mesosphere.io/name: kommander
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-4"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-beta.0"
+    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
+    appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
+    appversion.kubeaddons.mesosphere.io/karma: 1.4.1
+    appversion.kubeaddons.mesosphere.io/kommander-grafana: 6.6.0
+    endpoint.kubeaddons.mesosphere.io/thanos: /ops/portal/kommander/monitoring/query
+    endpoint.kubeaddons.mesosphere.io/karma: /ops/portal/kommander/monitoring/karma
+    endpoint.kubeaddons.mesosphere.io/kommander-grafana: "/ops/portal/kommander/monitoring/grafana"
+    docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
+    docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
+    docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
+spec:
+  namespace: kommander
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: kommander
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.10.1
+    values: |
+      ---
+      ingress:
+        extraAnnotations:
+          traefik.ingress.kubernetes.io/priority: "2"
+      kommander-licensing:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+      kommander-federation:
+        utilityApiserver:
+          minimumKubernetesVersion: 1.16.0
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+        konvoy:
+          allowUnofficialReleases: false
+        kubefed:
+          controllermanager:
+            annotations:
+              secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+            webhook:
+              annotations:
+                secret.reloader.stakater.com/reload: "kubefed-admission-webhook-serving-cert"
+      kommander-karma:
+        karma:
+          deployment:
+            annotations:
+              configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+              secret.reloader.stakater.com/reload: kommander-karma-client-tls
+      kommander-thanos:
+        thanos:
+          query:
+            deploymentAnnotations:
+              secret.reloader.stakater.com/reload: kommander-thanos-client-tls
+      kubeaddons-catalog:
+        ingress:
+          enable: false
+          hostName: catalog.kubeaddons.localhost
+          annotations: {}
+      kommander-ui:
+        podAnnotations: {}
+        #  iam.amazonaws.com/role: xyz
+      kubecost:
+        cost-analyzer:
+          kubecostDeployment:
+            labels:
+              vendor.kubecost.io/partner: d2iq
+          thanos:
+            query:
+              deploymentAnnotations:
+                secret.reloader.stakater.com/reload: kommander-kubecost-thanos-client-tls

--- a/addons/kommander/1.2.0/kommander-5.yaml
+++ b/addons/kommander/1.2.0/kommander-5.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-5"
     appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-beta.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.10.1
+    version: 0.10.3
     values: |
       ---
       ingress:


### PR DESCRIPTION
Supercedes #130 

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**

Chore

<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:

<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
fixes: cannot log out of UI from certain pages
feat: addons can now be upgraded from the catalog UI
feat: view infrastructure providers from the global context
feat: UI enhancements for cluster/project/workspace cost analysis
feat: UI now hides edit/delete actions based on role-based permissions
feat: licensing page more helpful when no license exists
feat: all pages now have contextual window titles
feat: improve workspace context menu with create and manage workspaces links
```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
