### PR TITLE
[D2IQ-71747] Add default upgrade testing to CI

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/googleapis/gnostic v0.5.1 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/mesosphere/ksphere-testing-framework v0.2.0
-	github.com/mesosphere/kubeaddons v0.20.0
+	github.com/mesosphere/kubeaddons v0.20.2
 	go.uber.org/zap v1.15.0 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -563,8 +563,10 @@ github.com/mesosphere/ksphere-testing-framework v0.2.0/go.mod h1:FMV0aXxxjC6+Q6R
 github.com/mesosphere/kubeaddons v0.10.2/go.mod h1:6TEL+jD4yW324GCF+aaIXNmBBgeeaF636DAi43OJffo=
 github.com/mesosphere/kubeaddons v0.11.0/go.mod h1:vUibt0jKmrxwRi2nDS7Os+Lz1PMqGVDG6HpdI0HUWGQ=
 github.com/mesosphere/kubeaddons v0.16.1/go.mod h1:CQd9wXoGtdH7iDQ00++WaiL/vJCsXNx22ug94P4z+X0=
-github.com/mesosphere/kubeaddons v0.20.0 h1:V73h56AmkElV56nd+yoqwi38DIfLJ599xvggQMT6Kso=
-github.com/mesosphere/kubeaddons v0.20.0/go.mod h1:HBLL0ZV1sGw5KNNtxJDALW8AiNsyY+c+FCerrQjFL90=
+github.com/mesosphere/kubeaddons v0.20.1 h1:ylsyaq5wz6/gqyTCl/VfaGP2ByzgqQEbkQTdQKLmRLQ=
+github.com/mesosphere/kubeaddons v0.20.1/go.mod h1:HBLL0ZV1sGw5KNNtxJDALW8AiNsyY+c+FCerrQjFL90=
+github.com/mesosphere/kubeaddons v0.20.2 h1:lThvyDh0slvCKKka5csl9D0nZTbomBdfqVXw+yyCn14=
+github.com/mesosphere/kubeaddons v0.20.2/go.mod h1:HBLL0ZV1sGw5KNNtxJDALW8AiNsyY+c+FCerrQjFL90=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/test/kommander_test.go
+++ b/test/kommander_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -9,10 +10,13 @@ import (
 	"github.com/mesosphere/ksphere-testing-framework/pkg/cluster/kind"
 	"github.com/mesosphere/ksphere-testing-framework/pkg/experimental"
 	testharness "github.com/mesosphere/ksphere-testing-framework/pkg/harness"
+	"github.com/mesosphere/kubeaddons/pkg/constants"
 	addontesters "github.com/mesosphere/kubeaddons/test/utils"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/cluster"
 )
+
+const comRepoRef = "master"
 
 func TestKommanderGroup(t *testing.T) {
 	t.Logf("testing group kommander")
@@ -55,21 +59,63 @@ func TestKommanderGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	found := false
+	addonUpgrades := testharness.Loadables{}
+	for _, addon := range addons {
+		if addon.GetName() != "kommander" {
+			continue
+		}
+		found = true
+
+		t.Logf("determining old and new versions of Kommander for upgrade testing")
+		oldAddon, err := addontesters.GetLatestAddonRevisionFromLocalRepoBranch("../", comRepoRef, "kommander")
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldVersion, err := semver.Parse(strings.TrimPrefix(oldAddon.GetAnnotations()[constants.AddonRevisionAnnotation], "v"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		newVersion, err := semver.Parse(strings.TrimPrefix(addon.GetAnnotations()[constants.AddonRevisionAnnotation], "v"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if oldVersion.GT(newVersion) {
+			t.Fatal(fmt.Errorf("new kommander version is %s which is below the previous version %s", newVersion, oldVersion))
+		}
+		if oldVersion.EQ(newVersion) {
+			t.Logf("Kommander itself was not updated, ignoring upgrade tests")
+			break
+		}
+
+		t.Logf("an upgrade test for Kommander from previous version %s to new version %s is needed", oldVersion, newVersion)
+		addonUpgrade, err := addontesters.UpgradeAddon(t, cluster, oldAddon, addon)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addonUpgrades = append(addonUpgrades, addonUpgrade)
+	}
+
+	if !found {
+		t.Fatal(fmt.Errorf("could not find kommander addon in test group, this shouldn't happen"))
+	}
+
 	th := testharness.NewSimpleTestHarness(t)
 	th.Load(
 		addontesters.ValidateAddons(addons...),
 		addonDeployment,
 		addonDefaults,
-		addonCleanup,
-		testharness.Loadable{
-			Plan: testharness.DefaultPlan,
-			Jobs: testharness.Jobs{
-				thanosChecker(t, cluster),
-				karmaChecker(t, cluster),
-				kubecostChecker(t, cluster),
-			},
+		addonCleanup)
+	th.Load(addonUpgrades...)
+	th.Load(testharness.Loadable{
+		Plan: testharness.DefaultPlan,
+		Jobs: testharness.Jobs{
+			thanosChecker(t, cluster),
+			karmaChecker(t, cluster),
+			kubecostChecker(t, cluster),
 		},
-	)
+	})
 
 	defer th.Cleanup()
 	th.Validate()


### PR DESCRIPTION
**What type of PR is this?**
Feature,Chore

**What this PR does/ why we need it**:
New updates to the Kommander addon will trigger an upgrade test from the previous `master` version in CI.

**Which issue(s) this PR fixes**:
D2IQ-71747

**Special notes for your reviewer**:
Blocked on https://github.com/mesosphere/kubeaddons/pull/979

**Does this PR introduce a user-facing change?**:
NONE

**Checklist**

- [x] The commit message explains the changes and why are needed.
- [x] The code builds and passes lint/style checks locally.
- [x] The relevant subset of integration tests pass locally.
- [x] The core changes are covered by tests.
- [x] The documentation is updated where needed.
