### PR TITLE
[D2IQ-72015] Fix storage race condition for Kommander addon

### DIFF
--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -18,8 +18,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/d71f1e0/stable/kommander/values.yaml"
-    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22",
-      "strategy": "delete"}]'
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
 spec:
   namespace: kommander
   kubernetes:

--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -19,6 +19,10 @@ metadata:
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/d71f1e0/stable/kommander/values.yaml"
     helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    # This was originally added to support the PVC's needed for the Kubecost subcomponent.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
 spec:
   namespace: kommander
   kubernetes:


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
- bug: fix broken annotation for Kommander addon
- bug: fix storage race condition for Kommander addon

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-72015

**Does this PR introduce a user-facing change?**:
```release-note
- the kommander addon will now wait for a default storage class before deploying in order to support the storage needed for kubecost components
```

**Checklist**

- [x] The commit message explains the changes and why are needed.
- [x] The code builds and passes lint/style checks locally.
- [x] The relevant subset of integration tests pass locally.
- [x] The core changes are covered by tests.
- [x] The documentation is updated where needed.
