### PR TITLE
Use the default upgrade strategy for Kommander

### DIFF
--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -18,8 +18,6 @@ metadata:
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/813c68d/stable/kommander/values.yaml"
-    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22",
-      "strategy": "delete"}]'
     # TODO: we're temporarily supporting dependency on an existing default storage class
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.


### PR DESCRIPTION
bug: remove the delete strategy from Kommander addon

The delete strategy was only triggered on very old versions of Kubeaddons,
however at this point we fully expect that Kommander should NEVER be
delete upgraded as to protect against deletion of federated resources.

This change should generally not really have any effect, but if nothing else should reduce confusion related to the annotation.

This is one of the situations where it is safe (in fact preferable) to remove this annotation without needing to bump the revision for the Addon.