### PR TITLE
Automated chart bump kommander-0.11.9

### DIFF
--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-13"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-14"
     appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-beta.2"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -17,7 +17,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/813c68d/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/ed78f66/stable/kommander/values.yaml"
     # TODO: we're temporarily supporting dependency on an existing default storage class
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.11.8
+    version: 0.11.9
     values: |
       ---
       ingress:


### PR DESCRIPTION
Fixes an issue where removing Kommander would cascade delete the `kubeaddons` namespace on managed clusters. It now orphans these instead to avoid disruptions to production services.