### PR TITLE
fix: requires-storageclass is a label not an annotation

### DIFF
--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -4,8 +4,12 @@ metadata:
   name: kommander
   labels:
     kubeaddons.mesosphere.io/name: kommander
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    # This was originally added to support the PVC's needed for the Kubecost subcomponent.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"    
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-16"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-17"
     appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.2"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -18,10 +22,6 @@ metadata:
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/fe2859e6/stable/kommander/values.yaml"
-    # TODO: we're temporarily supporting dependency on an existing default storage class
-    # on the cluster, this hack will trigger re-queue on Addons until one exists.
-    # This was originally added to support the PVC's needed for the Kubecost subcomponent.
-    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
 spec:
   namespace: kommander
   kubernetes:

--- a/test/vars_test.go
+++ b/test/vars_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	kbaURL    = "https://github.com/mesosphere/kubernetes-base-addons"
-	kbaRef    = "master"
+	kbaRef    = "release/2"
 	kbaRemote = "origin"
 
 	defaultKubernetesVersion = "1.18.8"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**

<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:

<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-72328)
* https://jira.d2iq.com/browse/D2iQ-72328
-->
https://jira.d2iq.com/browse/D2IQ-72328

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Prevent a race condition where kube-cost PVCs were being created before the default StoragaClass preventing PVs from being created.
```

**Checklist**

- [x] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
