### PR TITLE
Initial 1.3 Master Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This [KEP](https://github.com/mesosphere/ksphere-platform/blob/master/keps/sig-k
 
 Kommander currently is supported in three different versions, which are reporesented by their respective branches:
 
-- 1.2 being developed on `master` branch
+- 1.3 being developed on `master` branch
+- 1.2 living on `stable-1.2.x` branch
 - 1.1 living on `stable-1.1.x` branch
 - 1.0 living on `stable-1.0.x` branch
 

--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,8 +9,8 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-23"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.3.0-beta.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -3,9 +3,10 @@
     "enabled": true,
     "interactive": false,
     "fix_version_map": {
-      "master": "Kommander 1.2.0 RC 3",
+      "master": "Kommander 1.3.0 Beta 0",
       "stable-1.0.x": "Kommander 1.0.3",
-      "stable-1.1.x": "Kommander 1.1.3"
+      "stable-1.1.x": "Kommander 1.1.3",
+      "stable-1.2.x": "Kommander 1.2.0 RC 3"
     }
   }
 }


### PR DESCRIPTION
1.2 now lives on https://github.com/mesosphere/kubeaddons-kommander/tree/stable-1.2.x branch.