### PR TITLE
[master] Automated chart bump kommander-0.12.8

### DIFF
--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-2"
     appversion.kubeaddons.mesosphere.io/kommander: "1.3.0-beta.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/5f6f40a/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/7a77882/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.11.18
+    version: 0.12.8
     values: |
       ---
       ingress:


### PR DESCRIPTION
Add release note or "none":
```release-note
feat: remove conductor addon
feat: link to infra providers if that is why cluster can't delete
fix: remove finalizers from kommander clusters when force deleted (COPS-6626)
fix: reverted limiting service account to fix upgrade issue
```