### PR TITLE
[1.2] bump chart 0.12.6 -> 0.12.8

### DIFF
--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-28"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-29"
     appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.4"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.12.6
+    version: 0.12.8
     values: |
       ---
       ingress:

--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -10,7 +10,7 @@ metadata:
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-29"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.4"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.5"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1


### PR DESCRIPTION
not 100% sure what 0.12.7 bumped and why its not yet in the addon.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**

<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:

<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
feat: remove conductor addon
feat: link to infra providers if that is why cluster can't delete
fix: remove finalizers from kommander clusters when force deleted (COPS-6626)
fix: reverted limiting service account to fix upgrade issue
```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
