### PR TITLE
[1.2] chore: update k8s minSupportedVersion

### DIFF
--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-31"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-32"
     appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.5"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -25,7 +25,7 @@ metadata:
 spec:
   namespace: kommander
   kubernetes:
-    minSupportedVersion: v1.15.6
+    minSupportedVersion: v1.16.0
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: cert-manager

--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-32"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-33"
     appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.5"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21


### PR DESCRIPTION
I _think_ this was replaced by the utility server anyway, but lets keep it for release - not sure if something is still depending on it 🙈 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**

<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:

<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
