### PR TITLE
[1.2] e2e: Skip Kommander cleanup at the end

### DIFF
--- a/test/kommander_test.go
+++ b/test/kommander_test.go
@@ -144,7 +144,16 @@ kubeaddonsRepository:
 		t.Fatal(err)
 	}
 
-	addonCleanup, err := addontesters.CleanupAddons(t, cluster, addons...)
+	// there is well known bug of kommander not being able to be uninstalled
+	// https://jira.d2iq.com/browse/D2IQ-63395
+	// remove it from the addon cleanup list
+	addonsToCleanup := make([]v1beta2.AddonInterface, 0)
+	for _, addon := range addons {
+		if addon.GetName() != "kommander" {
+			addonsToCleanup = append(addonsToCleanup, addon)
+		}
+	}
+	addonCleanup, err := addontesters.CleanupAddons(t, cluster, addonsToCleanup...)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Dimitri Koshkin <dimitri.koshkin@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**

<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
After [recent kubeaddons changes](https://github.com/mesosphere/kubeaddons/pull/1062), the kubeaddons-controller will now fail on a delete error.
Currently, Kommander cannot be deleted, so removing it from the list of addons to cleanup.

<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
