### PR TITLE
Investigation: Revert "[1.2] e2e: Skip Kommander cleanup at the end"

### DIFF
--- a/test/kommander_test.go
+++ b/test/kommander_test.go
@@ -144,16 +144,7 @@ kubeaddonsRepository:
 		t.Fatal(err)
 	}
 
-	// there is well known bug of kommander not being able to be uninstalled
-	// https://jira.d2iq.com/browse/D2IQ-63395
-	// remove it from the addon cleanup list
-	addonsToCleanup := make([]v1beta2.AddonInterface, 0)
-	for _, addon := range addons {
-		if addon.GetName() != "kommander" {
-			addonsToCleanup = append(addonsToCleanup, addon)
-		}
-	}
-	addonCleanup, err := addontesters.CleanupAddons(t, cluster, addonsToCleanup...)
+	addonCleanup, err := addontesters.CleanupAddons(t, cluster, addons...)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Reverts mesosphere/kubeaddons-kommander#223

@dkoshkin I am reverting your PR to investigate this issue and understand why it is happening again.

Related JIRA tickets:

* https://jira.d2iq.com/browse/D2IQ-63395
* https://jira.d2iq.com/browse/D2IQ-73310