### PR TITLE
Dispatchfile: track releases instead of tags

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -1,4 +1,4 @@
-#!mesosphere/dispatch-starlark:v0.6
+#!mesosphere/dispatch-starlark:v0.8
 # vi:syntax=python
 #
 #
@@ -84,4 +84,4 @@ task("update-soak", inputs=[gitops, git], steps=[
 ])
 
 
-action(tasks=["update-soak"], on=tag(names=["*"]))
+action(tasks=["update-soak"], on=p.Condition(release=p.ReleaseCondition(tags=["v*"])))


### PR DESCRIPTION
**What this PR does/ why we need it**:
We were tracking tags while release triggers were being developed on Dispatch. Now release triggers work.

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
