### PR TITLE
Automated chart bump kommander-0.13.28

### DIFF
--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-30"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-31"
     appversion.kubeaddons.mesosphere.io/kommander: "1.3.0-rc.6"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/890e525/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/1456370/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.13.27
+    version: 0.13.28
     values: |
       ---
       kubecost:


### PR DESCRIPTION
Signed-off-by: Dimitri Koshkin <dimitri.koshkin@gmail.com>

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Similar change as https://github.com/mesosphere/charts/pull/964/files

```
k logs -n kommander      kommander-kubeaddons-set-grafana-home-dashboard-trigger-7gs2h
sh: /bin/bash: not found
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kommander: fix set-grafana-home-dashboard after it was updated to a new jq image.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
