### PR TITLE
[1.2.x] Bump kommander kubecost

### DIFF
--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -9,8 +9,8 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.0-36"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.2.0-rc.5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.1-0"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.2.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.12.16
+    version: 0.12.17
     values: |
       ---
       ingress:

--- a/addons/kommander/1.2/kommander.yaml
+++ b/addons/kommander/1.2/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.1-0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.1-1"
     appversion.kubeaddons.mesosphere.io/kommander: "1.2.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/659d0dd/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/44f444c0503d09246a3846f8733b98946d0d37f9/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.12.17
+    version: 0.12.18
     values: |
       ---
       ingress:

--- a/test/kommander_test.go
+++ b/test/kommander_test.go
@@ -139,11 +139,6 @@ kubeaddonsRepository:
 		Jobs: installAutoProvisioningJobs,
 	}
 
-	addonDeployment, err := addontesters.DeployAddons(t, cluster, addonsWithoutCertManager...)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// there is a bug of kommander not being able to be uninstalled
 	// https://jira.d2iq.com/browse/D2IQ-73310
 	// remove it from the addon cleanup list
@@ -189,6 +184,7 @@ kubeaddonsRepository:
 		}
 		if oldVersion.EQ(newVersion) {
 			t.Logf("Kommander itself was not updated, ignoring upgrade tests")
+			addonsWithoutCertManager = append(addonsWithoutCertManager, addon)
 			break
 		}
 
@@ -201,6 +197,11 @@ kubeaddonsRepository:
 		addonUpgrades = append(addonUpgrades, addonUpgrade)
 	}
 
+	addonDeployment, err := addontesters.DeployAddons(t, cluster, addonsWithoutCertManager...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if !found {
 		t.Fatal(fmt.Errorf("could not find kommander addon in test group, this shouldn't happen"))
 	}
@@ -210,7 +211,8 @@ kubeaddonsRepository:
 		addontesters.ValidateAddons(addons...),
 		installAutoProvisioning,
 	)
-	// Install kommander just once, using the upgrade test to avoid uninstalling it
+	// If upgrade test necessary, install kommander just once in the upgrade test to avoid uninstalling it
+	// If upgrade test not necessary, kommander deployed with addonDeployment
 	th.Load(addonUpgrades...)
 	th.Load(
 		addonDeployment,

--- a/test/kommander_test.go
+++ b/test/kommander_test.go
@@ -62,7 +62,7 @@ func TestKommanderGroup(t *testing.T) {
 	for _, addon := range addons {
 		if addon.GetName() == "cert-manager" {
 			certManagerAddon = addon
-		} else {
+		} else if addon.GetName() != "kommander" {
 			addonsWithoutCertManager = append(addonsWithoutCertManager, addon)
 		}
 	}
@@ -144,8 +144,8 @@ kubeaddonsRepository:
 		t.Fatal(err)
 	}
 
-	// there is well known bug of kommander not being able to be uninstalled
-	// https://jira.d2iq.com/browse/D2IQ-63395
+	// there is a bug of kommander not being able to be uninstalled
+	// https://jira.d2iq.com/browse/D2IQ-73310
 	// remove it from the addon cleanup list
 	addonsToCleanup := make([]v1beta2.AddonInterface, 0)
 	for _, addon := range addons {
@@ -209,11 +209,14 @@ kubeaddonsRepository:
 	th.Load(
 		addontesters.ValidateAddons(addons...),
 		installAutoProvisioning,
+	)
+	// Install kommander just once, using the upgrade test to avoid uninstalling it
+	th.Load(addonUpgrades...)
+	th.Load(
 		addonDeployment,
 		addonDefaults,
-		addonCleanup)
-	th.Load(addonUpgrades...)
-	th.Load(testharness.Loadable{
+		addonCleanup,
+		testharness.Loadable{
 		Plan: testharness.DefaultPlan,
 		Jobs: testharness.Jobs{
 			thanosChecker(t, cluster),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
bug
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
Bump chart for kubecost version bump to fix bug https://github.com/mesosphere/charts/pull/986. This will go into `1.2.x` stable branch to be released in kommander 1.2.1 patch (w/ konvoy 1.6.x patch don't actually know which is the next patch version 😬 )
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
fix: Bump kubecost to fix an issue that occasionally caused pods to fail to deploy
fix: Ensure pre-delete hook jobs are cleaned up
fix: Ensure kubectl deletes do not fail if resource already deleted
```

**Checklist**

- [x] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
