### PR TITLE
[1.3.x] Automated chart bump kommander-0.13.36

### DIFF
--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,8 +9,8 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-41"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.3.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.1-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.3.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1

--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-40"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-41"
     appversion.kubeaddons.mesosphere.io/kommander: "1.3.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/6e1079b/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/e49318e/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.13.35
+    version: 0.13.36
     values: |
       ---
       kubecost:

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -7,7 +7,7 @@
       "1.0.x": "Kommander 1.0.3",
       "1.1.x": "Kommander 1.1.4",
       "1.2.x": "Kommander 1.2.1",
-      "1.3.x":  "Kommander 1.3.1"
+      "1.3.x": "Kommander 1.3.1"
     }
   }
 }


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Chart uninstall may get stuck at 
```
  Warning  DriverDeployFailure  46m (x5 over 70m)    kubeaddons-controller  could not delete release: warning: Hook pre-delete kommander/templates/grafana/opsportal-username-secret.yaml failed: jobs.batch "cleanup-kommander-kubeaddons-ops-portal-username" already exists
```
The hook was missing a `before-hook-creation` delete annotation to ensure we don't run into the above error.

This needs to go into kommander 1.1/1.2/1.3 / konvoy 1.5/1.6/1.7 patches. Will backport this to the relevant chart versions. This kommander bump will go into komm1.3/konv1.7 patch

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-74255
https://jira.d2iq.com/browse/COPS-6821

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix(kommander): Ensure pre-delete hook jobs are cleaned up
fix(kommander): Ensure kubectl deletes do not fail if resource already deleted
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
