### PR TITLE
Bump chart to 0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ This is a [kubernetes addon](https://github.com/mesosphere/kubeaddons) repositor
 
 This [KEP](https://github.com/mesosphere/ksphere-platform/blob/master/keps/sig-ksphere-catalog/20200818-remove-revisions.md) changed the way we handle revision, which enables this repository to only maintain one revision per branch and removes the need to keep a flat hierarchy on master.
 
-Kommander currently is supported in three different versions, which are reporesented by their respective branches:
+Kommander currently is supported in three different versions, which are represented by their respective branches:
 
-- 1.3 being developed on `master` branch
+- 1.4 being developed on `master` branch
+- 1.3 living on `1.3.x` branch
 - 1.2 living on `1.2.x` branch
 - 1.1 living on `1.1.x` branch
 - 1.0 living on `1.0.x` branch
@@ -46,16 +47,20 @@ When a major issue in "beta 3" is found on SOAK, we will follow the steps above 
 
 ### Prepare Minor GA Release / Branch off maintenance branch
 
-New pre-releases mainly happen on master branch, at some point a `[0-9].[0-9].x` maintenance branch is created for to prepare the GA release of a minor version.
+New pre-releases mainly happen on master branch, at some point a `[0-9].[0-9].x` maintenance branch is created to prepare the GA release of a minor version.
 
 1. fetch latest repo state: `git fetch` and make sure you're on `master`
 1. create new `[0-9].[0-9].x` branch for that minor release: e.g. `git checkout -b 1.1.x`. that way future updates have an easy target and master can carry on with the next minor version.
-1. in order to allow backports to that newly reated minor version, make sure that the charts minor version also is bumped.
+1. in order to allow backports to that newly created minor version, make sure that the chart's minor version also is bumped.
 1. to make it easy for fellow colleagues, rename the existing directory on `master` (e.g. `1.1` -> `1.2`) and update the addons metadata (appversion & revision)
+1. update `mergebot-config.json` on `master` to add a new line for the new stable branch and update the `master` mapping to the next release
 
-From there on, its very similar to releases from `master` branch, there might be a couple RCs before the actual GA tag is cut.
+From there on, it's very similar to releases from `master` branch, there might be a couple RCs before the actual GA tag is cut. When the time comes to cut the GA release, promote the latest RC tags to GA tags: e.g. `v1.3.0` and corresponding stable tags `stable-1.17-1.3.0`, `stable-1.18-1.3.0`, `stable-1.19-1.3.0`.
 
 There is no need to merge back `[0-9].[0-9].x` branches into master since we don't need to maintain a flat history anymore.
+
+#### Release notes
+TBD
 
 ### Dealing with previously released stable versions
 
@@ -65,7 +70,7 @@ Sometimes we might need to push a fix for an older version, in these cases we ne
 
 1. fetch latest repo state: `git fetch`
 1. checkout respective stable branch: e.g. `git checkout 1.0.x`
-1. apply tag: e.g. `git tag v1.0.1 && git push origin v1.0.1`
+1. apply tags: e.g. `git tag v1.0.1 && git push origin v1.0.1` along with corresponding `stable` tags
 1. update `mergebot-config.json` on `master` and set its version to the next patch release
 
-There is no need to merge back `[0-9].[0-9].x` branches into master since we dont need to maintain a flat history anymore.
+There is no need to merge back `[0-9].[0-9].x` branches into master since we don't need to maintain a flat history anymore.

--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,8 +9,8 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-40"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.3.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.4.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.13.35
+    version: 0.14.0
     values: |
       ---
       kubecost:

--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -10,7 +10,7 @@ metadata:
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-1"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.4.0"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.4.0-beta.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.14.0
+    version: 0.15.0
     values: |
       ---
       kubecost:

--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/6e1079b/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/44e4931/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.15.0
+    version: 0.16.1
     values: |
       ---
       kubecost:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
chore
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
Bumps all the versions post 1.3 GA to prep for 1.4. 

<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
chore: Bump federated fluentbit to 0.7.1
fix: Bump kubecost to 0.5.4 to ensure kubectl deletes do not fail if resource already deleted
chore: Bump federated reloader to v0.0.80
feat: Bump go deps dependencies to konvoy
```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
