### PR TITLE
[auto-bump][chart] kommander-0.16.1

### DIFF
--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,19 +9,19 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-40"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.3.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.4.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1
-    appversion.kubeaddons.mesosphere.io/kommander-grafana: 6.6.0
+    appversion.kubeaddons.mesosphere.io/kommander-grafana: 1.4.0
     endpoint.kubeaddons.mesosphere.io/thanos: /ops/portal/kommander/monitoring/query
     endpoint.kubeaddons.mesosphere.io/karma: /ops/portal/kommander/monitoring/karma
     endpoint.kubeaddons.mesosphere.io/kommander-grafana: "/ops/portal/kommander/monitoring/grafana"
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/6e1079b/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/44e4931/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.13.35
+    version: 0.16.1
     values: |
       ---
       kubecost:


### PR DESCRIPTION
automated bumps for chore: batch requirements 0.9.0

This bumps the patch version of kommander chart since 0.16.0 was just a bump of version (no other changes) to prep for 1.4.0.