### PR TITLE
[1.3.x] Bump kommander to 0.15.2

### DIFF
--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.1-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.1-4"
     appversion.kubeaddons.mesosphere.io/kommander: "1.3.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/1f940fc/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/5285b196b3cb7f249f2df15ba98ee7027b562b2b/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.15.0
+    version: 0.15.2
     values: |
       ---
       kubecost:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
bug
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
Bumps kommander to latest patch version for 1.3.x. Includes yakcl and kommander-ui bumps
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-74140
https://jira.d2iq.com/browse/COPS-6821
https://jira.d2iq.com/browse/D2IQ-74255
https://jira.d2iq.com/browse/D2IQ-74458
https://jira.d2iq.com/browse/D2IQ-73852
https://jira.d2iq.com/browse/COPS-6844


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
fix: All federated addons/clusteraddons will now be successfully removed when Kubeaddons is disabled
fix(kubecost): Ensure kubectl deletes do not fail if resource already deleted 
fix: Reverts previous change to projects. Before, it created a default NetworkPolicy, which blocks ingress from other namespaces. Now, no default NetworkPolicy is created and no blocking is done.
fix: When self attaching a kommander cluster, dex-k8s-authenticator configmap is no longer updated as this caused invalid links on generate token page
fix: Fixes bug in Kommander UI where LDAP Root CA is malformed when saved
fix: Updates UI to only ship with needed dependencies
```

**Checklist**

- [x] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
