### PR TITLE
[auto-bump][chart] kommander-0.21.0

### DIFF
--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-8"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-9"
     appversion.kubeaddons.mesosphere.io/kommander: "1.4.0-beta.2"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/38b917c/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/666659c/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.19.3
+    version: 0.21.0
     values: |
       ---
       namespaceLabels:


### PR DESCRIPTION
Bumps yakcl to v0.11.0 and kommander-ui to 6.92.0 which turns on the helm releases feature (backend released in yakcl v0.11.0)

```
feat: Add kubetunnel integration
fix: Default labels are now getting passed into federation controller manager deployment
feat: Adds controller that deploys cluster-observer addon per kommandercluster
feat: Show status of Helm Releases in Kommander UI
```