### PR TITLE
[1.3.x] Bump kommander-ui, kubecost, yakcl

### DIFF
--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.2-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.2-3"
     appversion.kubeaddons.mesosphere.io/kommander: "1.3.2"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/34a580ca25b573071c5a7e4d01cab75e4b9b10ae/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/9dc05ee23c7440a978423c69e000da78fb324c5a/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.15.5
+    version: 0.15.6
     values: |
       ---
       kubecost:

--- a/addons/kommander/1.3/kommander.yaml
+++ b/addons/kommander/1.3/kommander.yaml
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/9dc05ee23c7440a978423c69e000da78fb324c5a/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/32f07b8ce6ae9c516879d93c1d5b551b29e03449/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.15.6
+    version: 0.15.8
     values: |
       ---
       kubecost:

--- a/test/kommander_test.go
+++ b/test/kommander_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -23,7 +24,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 )
 
-const comRepoRef = "master"
+const defaultKommanderRepoRef = "master"
 
 // autoProvisioningChartPath is a path to the `auto-provisioning` chart
 // that can be used to install `auto-provisioning` from `konvoy`.
@@ -37,8 +38,18 @@ const initialE2EKindConfigPath = "artifacts/kind-config.yaml"
 const dockerUsernameEnv = "DOCKERHUB_ROBOT_USERNAME"
 const dockerPasswordEnv = "DOCKERHUB_ROBOT_TOKEN"
 
+var kommanderBranchFlag = flag.String("kommander-branch", "", "")
+var kommanderRepoRef string
+
 func TestKommanderGroup(t *testing.T) {
 	t.Logf("testing group kommander")
+
+	flag.Parse()
+	if *kommanderBranchFlag != "" {
+		kommanderRepoRef = *kommanderBranchFlag
+	} else {
+		kommanderRepoRef = defaultKommanderRepoRef
+	}
 
 	createOption := cluster.CreateWithV1Alpha4Config(&v1alpha4.Cluster{})
 	// If we are in CI, we set the ImageRegistries to use the Docker Hub credentials.
@@ -187,7 +198,7 @@ kubeaddonsRepository:
 		found = true
 
 		t.Logf("determining old and new versions of Kommander for upgrade testing")
-		oldAddon, err := addontesters.GetLatestAddonRevisionFromLocalRepoBranch("../", "origin", comRepoRef, "kommander")
+		oldAddon, err := addontesters.GetLatestAddonRevisionFromLocalRepoBranch("../", "origin", kommanderRepoRef, "kommander")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
bug
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
Bumps kommander-ui in kommander (https://github.com/mesosphere/charts/pull/1083)
Bumps kubecost, bumps yakcl
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-74749

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- fix: UI update to handle new KUDO param types
- feat: Enables PodSecurityPolicy in Kubecost
- fix: No duplication of namespaces for a single workspace, anymore
- fix: FederatedKubeaddons controller no longer errors if there are no managed resources that need finalizers applied
```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
