### PR TITLE
[auto-bump][chart] kommander-0.25.1

### DIFF
--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-14"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-15"
     appversion.kubeaddons.mesosphere.io/kommander: "1.4.0-rc.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/b9bce4c/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/bb281b4/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.24.0
+    version: 0.25.1
     values: |
       ---
       namespaceLabels:


### PR DESCRIPTION
semi-automated bumps for chore: bump thanos to ~~0.3.22~~  0.3.31 - this is the latest patch before the jump to 0.4.0. Which we should also upgrade to but we'll do it in another PR.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- UI: adds ability to attach clusters with network restrictions
```