### PR TITLE
[auto-bump][chart] kommander-0.30.0

### DIFF
--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-18"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.0-19"
     appversion.kubeaddons.mesosphere.io/kommander: "1.4.0-rc.2"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/06972aa/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/50e1722/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.29.4
+    version: 0.30.0
     values: |
       ---
       namespaceLabels:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
bump yakcl to latest

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- fix: Update UI dependencies to mitigate CVE-2021-23337
- fix: Federated addon info is now displayed properly in UI cards
- fix: Bumps federated Kubeaddons to v0.26.1 to fix a bug causing unnecessary addon deployment delays
- feat: Upgrades federated Prometheus to 12.11.10, which includes a change to use the kube-prometheus-stack upstream chart following the deprecation of helm/charts.
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
