### PR TITLE
fix: Bump kommander to 0.32.0

### DIFF
--- a/addons/kommander/1.5/kommander.yaml
+++ b/addons/kommander/1.5/kommander.yaml
@@ -9,8 +9,8 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-1"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.5.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-2"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.5.0-beta.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/b12ed8f/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/fb870d749fa37dc6e54b109c657d7b89936b0cac/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.31.1
+    version: 0.32.0
     values: |
       ---
       namespaceLabels:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
bumps kubecost to latest to fix pvc sizing issue. will backport to 1.4.x

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-75770

**Special notes for your reviewer**:
Will open backport for komm1.3. we can use this for 1.4 since no non-1.4 changes have gone into the chart since last release

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix(kubecost): Increase default cost-analyzer persistent volume size to 32Gi. Upgrades may require manual intervention if your provisioner does not support volume expansion. (COPS-6937)
feat(kubecost): Migrate to new Allocation view. Legacy view to remain available at /detail.html
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
