### PR TITLE
chore: Revert addon revisions back to 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This [KEP](https://github.com/mesosphere/ksphere-platform/blob/master/keps/sig-k
 
 Kommander currently is supported in three different versions, which are represented by their respective branches:
 
-- 1.5 being developed on `master` branch
-- 1.4 living on `1.4.x` branch
+- 1.4 being developed on `master` branch, since we may not be releasing 1.5. We can continue working off `master` for 1.4 patches until we determine that there will be a 1.5 release.
+- 1.4 living on `1.4.x` branch (should stay in line with `master`)
 - 1.3 living on `1.3.x` branch
 - 1.2 living on `1.2.x` branch
 - 1.1 living on `1.1.x` branch

--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,8 +9,8 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-2"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.5.0-beta.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.1-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.4.1"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -3,7 +3,7 @@
     "enabled": true,
     "interactive": false,
     "fix_version_map": {
-      "master": "Kommander 1.5.0 Beta 0",
+      "master": "Kommander 1.4.1",
       "1.0.x": "Kommander 1.0.3",
       "1.1.x": "Kommander 1.1.4",
       "1.2.x": "Kommander 1.2.2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
chore
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
Since we may not ever be releasing kommander 1.5, let's revert the addon revision in `master` back to 1.4 so that we can continue to work off `master` instead of backporting every change to `1.4.x`. We should try to remember to merge `master` back into `1.4.x` so it does not get too far behind in case we ever do release a 1.5 qnd need to start using the 1.4.x release branch.
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
