### PR TITLE
chore: update mergebot-config release version

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -3,7 +3,7 @@
     "enabled": true,
     "interactive": false,
     "fix_version_map": {
-      "master": "Kommander 1.4.1",
+      "master": "Kommander 1.5.0",
       "1.0.x": "Kommander 1.0.3",
       "1.1.x": "Kommander 1.1.4",
       "1.2.x": "Kommander 1.2.2",

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -3,7 +3,7 @@
     "enabled": true,
     "interactive": false,
     "fix_version_map": {
-      "master": "Kommander 1.5.0",
+      "master": "Kommander 1.4.3",
       "1.0.x": "Kommander 1.0.3",
       "1.1.x": "Kommander 1.1.4",
       "1.2.x": "Kommander 1.2.2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**

Chore

**What this PR does/ why we need it**:

Technically, we don't have any plans to release Kommander 1.5.0 but any merges to master branch should reflect the next minor version. 

Right now merging to master means JIRA tickets get tagged with Kommander 1.4.1 and backporting commits to `1.4.x` branch means the same tickets get updated with `1.4.3` which is confusing.

Note: when we release Kommander 1.4.3 we'll need to update this file again.
