### PR TITLE
[auto-bump][chart] kommander-0.38.2

### DIFF
--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.3-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.3-2"
     appversion.kubeaddons.mesosphere.io/kommander: "1.4.3"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,32 +21,32 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/7ee256f/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/d7c9335/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
     minSupportedVersion: v1.16.0
   requires:
-  - matchLabels:
-      kubeaddons.mesosphere.io/name: cert-manager
-      kubeaddons.mesosphere.io/cert-manager: v1
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+        kubeaddons.mesosphere.io/cert-manager: v1
   cloudProvider:
-  - name: aws
-    enabled: true
-  - name: azure
-    enabled: true
-  - name: gcp
-    enabled: true
-  - name: vsphere
-    enabled: true
-  - name: docker
-    enabled: true
-  - name: none
-    enabled: true
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: vsphere
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.38.1
+    version: 0.38.2
     values: |
       ---
       namespaceLabels:

--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -27,22 +27,22 @@ spec:
   kubernetes:
     minSupportedVersion: v1.16.0
   requires:
-    - matchLabels:
-        kubeaddons.mesosphere.io/name: cert-manager
-        kubeaddons.mesosphere.io/cert-manager: v1
+  - matchLabels:
+      kubeaddons.mesosphere.io/name: cert-manager
+      kubeaddons.mesosphere.io/cert-manager: v1
   cloudProvider:
-    - name: aws
-      enabled: true
-    - name: azure
-      enabled: true
-    - name: gcp
-      enabled: true
-    - name: vsphere
-      enabled: true
-    - name: docker
-      enabled: true
-    - name: none
-      enabled: true
+  - name: aws
+    enabled: true
+  - name: azure
+    enabled: true
+  - name: gcp
+    enabled: true
+  - name: vsphere
+    enabled: true
+  - name: docker
+    enabled: true
+  - name: none
+    enabled: true
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
As COPS-7078 showed, some of the URLs we were using were relative thus causing them to be proxied through proxy if `http_proxy` variables were set. In order to prevent that, we need to use absolute names instead, so that the requests fall into `no_proxy` whitelist by default, without the need for the user to manually adjust anything.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/COPS-7078 

**Special notes for your reviewer**:
I have not tested it yet. Correctly recreating the environment customer is using is around 0.5day. I asked our support to help customer test it instead and come back to us as this will be much easier for them - the already have the test environment up&running.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Some of the URLS used kommander are now absolute - have cluster.local extension by default.
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
