### PR TITLE
[auto-bump][chart] kommander-0.38.4

### DIFF
--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,7 +9,7 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.3-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.3-2"
     appversion.kubeaddons.mesosphere.io/kommander: "1.4.3"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
@@ -21,32 +21,32 @@ metadata:
     docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
     docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
     docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/7ee256f/stable/kommander/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/5fda29e/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:
     minSupportedVersion: v1.16.0
   requires:
-  - matchLabels:
-      kubeaddons.mesosphere.io/name: cert-manager
-      kubeaddons.mesosphere.io/cert-manager: v1
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+        kubeaddons.mesosphere.io/cert-manager: v1
   cloudProvider:
-  - name: aws
-    enabled: true
-  - name: azure
-    enabled: true
-  - name: gcp
-    enabled: true
-  - name: vsphere
-    enabled: true
-  - name: docker
-    enabled: true
-  - name: none
-    enabled: true
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: vsphere
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.38.1
+    version: 0.38.4
     values: |
       ---
       namespaceLabels:

--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -27,22 +27,22 @@ spec:
   kubernetes:
     minSupportedVersion: v1.16.0
   requires:
-    - matchLabels:
-        kubeaddons.mesosphere.io/name: cert-manager
-        kubeaddons.mesosphere.io/cert-manager: v1
+  - matchLabels:
+      kubeaddons.mesosphere.io/name: cert-manager
+      kubeaddons.mesosphere.io/cert-manager: v1
   cloudProvider:
-    - name: aws
-      enabled: true
-    - name: azure
-      enabled: true
-    - name: gcp
-      enabled: true
-    - name: vsphere
-      enabled: true
-    - name: docker
-      enabled: true
-    - name: none
-      enabled: true
+  - name: aws
+    enabled: true
+  - name: azure
+    enabled: true
+  - name: gcp
+    enabled: true
+  - name: vsphere
+    enabled: true
+  - name: docker
+    enabled: true
+  - name: none
+    enabled: true
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable


### PR DESCRIPTION
Closes D2IQ-81807

**What type of PR is this?**
Feature: [Adds socket monitoring](https://github.com/mesosphere/kommander-ui/commit/37f63d5e851943b6994894602ce782be591bbab7)

Fix: [Pins docker version](https://github.com/mesosphere/kommander-ui/commit/fd51337c218ea9c3b7296ed442cd54459bc473f0)

**What this PR does/ why we need it**:
There is an issue where Kommander UI runs out of ports. This monitors ports and forces a restart if it runs out.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
