### PR TITLE
chore: Bump appversion to 1.4.4

### DIFF
--- a/addons/kommander/1.4/kommander.yaml
+++ b/addons/kommander/1.4/kommander.yaml
@@ -9,8 +9,8 @@ metadata:
     # This was originally added to support the PVC's needed for the Kubecost subcomponent.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.3-4"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.4.3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.4.4-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.4.4"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.21
     appversion.kubeaddons.mesosphere.io/karma: 1.4.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
chore
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
in prep for 1.4.4 release we need to bump the appversion annotations (we should have bumped this after 1.4.3 was released 😬 )
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```

**Checklist**

- [ ] The commit message explains the changes and why are needed.
- [ ] The code builds and passes lint/style checks locally.
- [ ] The relevant subset of integration tests pass locally.
- [ ] The core changes are covered by tests.
- [ ] The documentation is updated where needed.
